### PR TITLE
ci(sync-docs): use shared REPO_TOKEN secret

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,7 +1,7 @@
-# Requires repository secret VC_DOCS_BOT_TOKEN — a personal access token
-# (or GitHub App installation token) with write access to VirtoCommerce/vc-docs
-# (specifically: contents:write and pull-requests:write).
-# Set up via Settings → Secrets and variables → Actions.
+# Uses the org-wide REPO_TOKEN secret (PAT or GitHub App installation token)
+# that must have contents:write and pull-requests:write on VirtoCommerce/vc-docs.
+# Same secret is used by release.yml and storybook-ci.yml in this repo and by
+# deploy.yml in vc-docs. Configure via Settings → Secrets and variables → Actions.
 name: sync-docs
 
 on:
@@ -28,7 +28,7 @@ jobs:
         with:
           repository: VirtoCommerce/vc-docs
           path: vc-docs
-          token: ${{ secrets.VC_DOCS_BOT_TOKEN }}
+          token: ${{ secrets.REPO_TOKEN }}
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_branch || 'main' }}
       - uses: actions/setup-node@v4
         with:
@@ -44,7 +44,7 @@ jobs:
             --report ./sync-report.md
       - name: Open PR
         env:
-          GH_TOKEN: ${{ secrets.VC_DOCS_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TARGET_BRANCH: ${{ inputs.target_branch }}
           INPUT_REF_LABEL: ${{ inputs.ref_label }}

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -7,10 +7,20 @@ name: sync-docs
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "vc-docs branch to checkout and open the PR against (defaults to main)"
+        required: false
+        default: main
+      ref_label:
+        description: "Label used in the auto-PR branch name and title (defaults to a UTC timestamp)"
+        required: false
+        default: ""
 
 jobs:
   sync:
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +29,7 @@ jobs:
           repository: VirtoCommerce/vc-docs
           path: vc-docs
           token: ${{ secrets.VC_DOCS_BOT_TOKEN }}
-          ref: main
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_branch || 'main' }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -35,8 +45,28 @@ jobs:
       - name: Open PR
         env:
           GH_TOKEN: ${{ secrets.VC_DOCS_BOT_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TARGET_BRANCH: ${{ inputs.target_branch }}
+          INPUT_REF_LABEL: ${{ inputs.ref_label }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          BRANCH="auto/sync-vc-shell-${{ github.event.release.tag_name }}"
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            BASE="$INPUT_TARGET_BRANCH"
+            LABEL="$INPUT_REF_LABEL"
+            if [[ -z "$LABEL" ]]; then
+              LABEL="manual-$(date -u +%Y%m%d-%H%M%S)"
+            fi
+            BRANCH="auto/sync-vc-shell-${LABEL}"
+            TITLE="docs: manual sync from vc-shell (${LABEL})"
+          else
+            BASE="main"
+            LABEL="$RELEASE_TAG"
+            BRANCH="auto/sync-vc-shell-${LABEL}"
+            TITLE="docs: sync from vc-shell@${LABEL}"
+          fi
+
           cd vc-docs
           if [[ -z "$(git status --porcelain)" ]]; then
             echo "No changes to sync."
@@ -46,11 +76,11 @@ jobs:
           git config user.email "bot@virto.dev"
           git config user.name "vc-shell-docs-bot"
           git add .
-          git commit -m "docs: sync from vc-shell@${{ github.event.release.tag_name }}"
+          git commit -m "$TITLE"
           git push origin "$BRANCH"
           gh pr create \
-            --base main \
+            --base "$BASE" \
             --head "$BRANCH" \
-            --title "docs: sync from vc-shell@${{ github.event.release.tag_name }}" \
+            --title "$TITLE" \
             --body-file ../sync-report.md \
             --label auto-generated


### PR DESCRIPTION
## Summary

Hotfix on top of #223 / #224. The new workflow_dispatch trigger fails immediately with `Input required and not supplied: token` because the `VC_DOCS_BOT_TOKEN` secret was never provisioned in this repo. Switch to the org-wide `REPO_TOKEN` secret that is already used by `release.yml` and `storybook-ci.yml` in this repo, and by `deploy.yml` in vc-docs — one secret to rotate instead of two.

## What changes

- `.github/workflows/sync-docs.yml`:
  - `token: \${{ secrets.VC_DOCS_BOT_TOKEN }}` → `token: \${{ secrets.REPO_TOKEN }}` (both checkout step and `GH_TOKEN` env on the PR step)
  - Update top-of-file comment to reference REPO_TOKEN

## Behavior

No behavioral change. Same workflow, same triggers, same auto-PR shape (with `auto-generated` label). Only the underlying token identity differs.

`REPO_TOKEN` must have `contents:write` and `pull-requests:write` on `VirtoCommerce/vc-docs` — same permissions docs-deploy already exercises in vc-docs.

## Test plan

- [ ] After merge: Actions → sync-docs → Run workflow → `target_branch: docs/vc-shell-integration` → Run
- [ ] Verify auto-PR opens against the specified branch with the `auto-generated` label, no token error