### PR TITLE
fix(sync-docs): use absolute paths for sync target and report

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -38,10 +38,12 @@ jobs:
       - run: yarn install --immutable
       - run: yarn workspace @vc-shell/docs-sync build
       - name: Run sync
+        env:
+          WORKSPACE_DIR: ${{ github.workspace }}
         run: |
           yarn workspace @vc-shell/docs-sync exec docs-sync sync \
-            --target ./vc-docs \
-            --report ./sync-report.md
+            --target "$WORKSPACE_DIR/vc-docs" \
+            --report "$WORKSPACE_DIR/sync-report.md"
       - name: Open PR
         env:
           GH_TOKEN: ${{ secrets.REPO_TOKEN }}
@@ -82,5 +84,5 @@ jobs:
             --base "$BASE" \
             --head "$BRANCH" \
             --title "$TITLE" \
-            --body-file ../sync-report.md \
+            --body-file "$GITHUB_WORKSPACE/sync-report.md" \
             --label auto-generated


### PR DESCRIPTION
## Summary

`yarn workspace @vc-shell/docs-sync exec` runs commands with `cwd` set to the workspace package's directory (`cli/docs-sync/`), not the repo root. The previous `--target ./vc-docs` therefore resolved to `cli/docs-sync/vc-docs/` inside the workflow workspace — not the vc-docs checkout at `\$GITHUB_WORKSPACE/vc-docs`.

The writer silently created files at the wrong path (it does `mkdir -p` recursively), so `git status` in the real vc-docs checkout reported no changes, and the workflow exited with "No changes to sync" without opening a PR.

## What changes

Pass absolute paths via `\$GITHUB_WORKSPACE`:

- `--target "\$WORKSPACE_DIR/vc-docs"`
- `--report "\$WORKSPACE_DIR/sync-report.md"`
- `--body-file "\$GITHUB_WORKSPACE/sync-report.md"`

## How to verify

After merge: Actions → sync-docs → Run workflow with `target_branch: docs/vc-shell-integration`. Auto-PR should open with the 127 expected file changes.