### PR TITLE
fix(ai-agent): return undefined from useAiAgent() if not provided

### DIFF
--- a/framework/core/plugins/ai-agent/composables/useAiAgent.test.ts
+++ b/framework/core/plugins/ai-agent/composables/useAiAgent.test.ts
@@ -122,13 +122,12 @@ function mountWithAiAgentProvider(options?: {
 }
 
 describe("useAiAgent", () => {
-  it("throws when service is not provided", () => {
+  it("returns undefined when service is not provided", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
-      expect(() => {
-        mountWithSetup(() => useAiAgent());
-      }).toThrow();
+      const { result } = mountWithSetup(() => useAiAgent());
+      expect(result).toBeUndefined();
     } finally {
       warnSpy.mockRestore();
       errorSpy.mockRestore();

--- a/framework/core/plugins/ai-agent/composables/useAiAgent.ts
+++ b/framework/core/plugins/ai-agent/composables/useAiAgent.ts
@@ -7,7 +7,7 @@ import type {
   IAiAgentMessage,
   IAiAgentBladeContext,
 } from "@core/plugins/ai-agent/types";
-import { createLogger, InjectionError } from "@core/utilities";
+import { createLogger } from "@core/utilities";
 import { useUser } from "@core/composables/useUser";
 import { useBlade } from "@core/composables/useBlade";
 import { useBladeStack } from "@core/blade-navigation";
@@ -183,11 +183,11 @@ export interface UseAiAgentReturn {
  * });
  * ```
  */
-export function useAiAgent(): UseAiAgentReturn {
+export function useAiAgent(): UseAiAgentReturn | undefined {
   const service = inject(AiAgentServiceKey);
   if (!service) {
     logger.error("AiAgentService not found. Did you forget to call provideAiAgentService()?");
-    throw new InjectionError("AiAgentService");
+    return;
   }
 
   return {


### PR DESCRIPTION
## Summary

- The AI Agent plugin is optional: `aiAgentPlugin.install()` and `useShellBootstrap()` both skip `provideAiAgentService()` when no URL is configured. `useAiAgent()` was the lone consumer that threw `InjectionError` on that legitimate state, crashing host apps that don't configure the AI assistant URL.
- `useAiAgent()` now returns `undefined` in that case. Return type widened to `UseAiAgentReturn | undefined`; callers must guard the result. This aligns with the already-graceful `useAiAgentContext()` and the optional nature of the plugin.
- Unused `InjectionError` import removed; the "throws when service is not provided" unit test rewritten to assert the new `undefined` return.

## Test plan

- [x] `cd framework && npx vitest run core/plugins/ai-agent` — 30/30 tests pass
- [x] `yarn typecheck` — clean
- [x] `yarn check:locales` and `yarn check:layers` — pass via pre-commit hook
- [x] Manual: open a host app with no `AiAssistantUrl` configured and a blade that calls `useAiAgent()`; verify no crash (just a `logger.error` line in the console).
- [x] Manual: with `AiAssistantUrl` set, AI panel still opens and works as before.