### PR TITLE
chore(docs-sync): write .nav.yml instead of .pages (vc-docs awesome-nav v3)

### DIFF
--- a/cli/docs-sync/src/commands/sync.ts
+++ b/cli/docs-sync/src/commands/sync.ts
@@ -124,7 +124,7 @@ export async function runSync(args: SyncArgs): Promise<{ exitCode: number }> {
     }
   }
 
-  // Emit .pages files.
+  // Emit .nav.yml files.
   if (!args.dryRun) {
     await writePagesFiles(targetSection, { synced });
   }

--- a/cli/docs-sync/src/writer/pages.ts
+++ b/cli/docs-sync/src/writer/pages.ts
@@ -41,10 +41,10 @@ const NESTED_TITLES: Record<string, string> = {
   cli: "CLI",
 };
 
-// Folders for which the generator emits .pages.
+// Folders for which the generator emits .nav.yml.
 const AUTO_PAGES_TOP = new Set(["components", "composables", "plugins"]);
 const AUTO_PAGES_REFERENCE_SUB = new Set(["api", "api/directives", "modules"]);
-// concepts/ and reference root NOT in auto set — manual .pages.
+// concepts/ and reference root NOT in auto set — manual .nav.yml.
 
 export interface SyncedPage {
   target: string; // e.g. components/data-display/vc-data-table.md
@@ -71,7 +71,7 @@ export async function writePagesFiles(targetRoot: string, args: WritePagesArgs):
   for (const [top, groups] of byTopFolder) {
     const isAutoTop = AUTO_PAGES_TOP.has(top);
 
-    // Emit top-level .pages for components / composables / plugins.
+    // Emit top-level .nav.yml for components / composables / plugins.
     if (isAutoTop) {
       const hasOnlyRoot = groups.size === 1 && groups.has("");
       let navContent: string;
@@ -86,14 +86,14 @@ export async function writePagesFiles(targetRoot: string, args: WritePagesArgs):
         navContent = order.map((g) => `  - ${g}`).join("\n");
       }
       const yaml = PAGES_MARKER + `title: ${TOP_LEVEL_TITLES[top]}\n` + `nav:\n` + navContent + "\n";
-      const filePath = path.join(targetRoot, top, ".pages");
+      const filePath = path.join(targetRoot, top, ".nav.yml");
       await fs.mkdir(path.dirname(filePath), { recursive: true });
       await writeAtomic(filePath, yaml);
     }
 
-    // Emit per-group .pages.
+    // Emit per-group .nav.yml.
     for (const [group, pages] of groups) {
-      if (!group) continue; // single-file in top folder (e.g. concepts/services.md) — no group .pages
+      if (!group) continue; // single-file in top folder (e.g. concepts/services.md) — no group .nav.yml
       const isReferenceSub = top === "reference" && AUTO_PAGES_REFERENCE_SUB.has(group);
       if (!isAutoTop && !isReferenceSub) continue; // skip mixed/manual folders
 
@@ -108,7 +108,7 @@ export async function writePagesFiles(targetRoot: string, args: WritePagesArgs):
 
       const yaml = PAGES_MARKER + `title: ${groupTitle}\n` + `nav:\n` + navLines.join("\n") + "\n";
 
-      const filePath = path.join(targetRoot, top, group, ".pages");
+      const filePath = path.join(targetRoot, top, group, ".nav.yml");
       await fs.mkdir(path.dirname(filePath), { recursive: true });
       await writeAtomic(filePath, yaml);
     }

--- a/cli/docs-sync/tests/pages.test.ts
+++ b/cli/docs-sync/tests/pages.test.ts
@@ -13,20 +13,20 @@ describe("writePagesFiles", () => {
     await fs.rm(tmp, { recursive: true, force: true });
   });
 
-  it("emits a top-level components/.pages with subgroups in declared order", async () => {
+  it("emits a top-level components/.nav.yml with subgroups in declared order", async () => {
     await writePagesFiles(tmp, {
       synced: [
         { target: "components/data-display/vc-data-table.md", title: "VcDataTable" },
         { target: "components/misc/vc-button.md", title: "VcButton" },
       ],
     });
-    const top = await fs.readFile(path.join(tmp, "components/.pages"), "utf8");
+    const top = await fs.readFile(path.join(tmp, "components/.nav.yml"), "utf8");
     expect(top).toContain("AUTO-GENERATED FROM vc-shell");
     expect(top).toContain("title: Components");
     expect(top.indexOf("data-display")).toBeLessThan(top.indexOf("misc"));
   });
 
-  it("emits a per-group .pages alphabetically by title", async () => {
+  it("emits a per-group .nav.yml alphabetically by title", async () => {
     await writePagesFiles(tmp, {
       synced: [
         { target: "components/form/vc-input.md", title: "VcInput" },
@@ -34,25 +34,25 @@ describe("writePagesFiles", () => {
         { target: "components/form/vc-select.md", title: "VcSelect" },
       ],
     });
-    const group = await fs.readFile(path.join(tmp, "components/form/.pages"), "utf8");
+    const group = await fs.readFile(path.join(tmp, "components/form/.nav.yml"), "utf8");
     const lines = group.split("\n").filter((l) => l.startsWith("  - "));
     expect(lines).toEqual(["  - VcCheckbox: vc-checkbox.md", "  - VcInput: vc-input.md", "  - VcSelect: vc-select.md"]);
   });
 
-  it("does NOT emit .pages for concepts (mixed-folder)", async () => {
+  it("does NOT emit .nav.yml for concepts (mixed-folder)", async () => {
     await writePagesFiles(tmp, {
       synced: [{ target: "concepts/services.md", title: "Services" }],
     });
     let exists = true;
     try {
-      await fs.access(path.join(tmp, "concepts/.pages"));
+      await fs.access(path.join(tmp, "concepts/.nav.yml"));
     } catch {
       exists = false;
     }
     expect(exists).toBe(false);
   });
 
-  it("emits a flat plugins/.pages with explicit titles, alphabetical", async () => {
+  it("emits a flat plugins/.nav.yml with explicit titles, alphabetical", async () => {
     await writePagesFiles(tmp, {
       synced: [
         { target: "plugins/signalr.md", title: "SignalR" },
@@ -60,7 +60,7 @@ describe("writePagesFiles", () => {
         { target: "plugins/i18n.md", title: "Internationalization" },
       ],
     });
-    const pagesFile = await fs.readFile(path.join(tmp, "plugins/.pages"), "utf8");
+    const pagesFile = await fs.readFile(path.join(tmp, "plugins/.nav.yml"), "utf8");
     expect(pagesFile).toContain("AUTO-GENERATED FROM vc-shell");
     expect(pagesFile).toContain("title: Plugins");
     const lines = pagesFile.split("\n").filter((l) => l.startsWith("  - "));
@@ -79,7 +79,7 @@ describe("writePagesFiles", () => {
         { target: "composables/services/useToolbar.md", title: "useToolbar" },
       ],
     });
-    const pagesFile = await fs.readFile(path.join(tmp, "composables/services/.pages"), "utf8");
+    const pagesFile = await fs.readFile(path.join(tmp, "composables/services/.nav.yml"), "utf8");
     const lines = pagesFile.split("\n").filter((l) => l.startsWith("  - "));
     expect(lines).toEqual([
       "  - Overview: index.md",


### PR DESCRIPTION
## Summary

- `vc-docs` upgraded `mkdocs-awesome-pages-plugin` (v2) → `mkdocs-awesome-nav` (v3), which uses `.nav.yml` as its default config filename. All `.pages` files in `vc-docs` were renamed to `.nav.yml`.
- `docs-sync` writes nav config into the published `vc-docs` tree under `custom-apps-development/vc-shell/`. Without this change the next sync would write `.pages` files alongside the renamed `.nav.yml` files, and awesome-nav v3 would ignore the `.pages` files — breaking navigation for components, composables, and plugins.

## Changes

- `cli/docs-sync/src/writer/pages.ts` — emit `.nav.yml` instead of `.pages`
- `cli/docs-sync/src/commands/sync.ts` — comment update
- `cli/docs-sync/tests/pages.test.ts` — assert against `.nav.yml` paths

## Test plan

- [x] `npm test` — all 60 docs-sync tests pass
- [ ] Run `docs-sync` against the merged vc-docs branch and confirm it writes `.nav.yml` in `custom-apps-development/vc-shell/{components,composables,plugins}/` and their sub-groups

## Companion

Companion PR in `vc-docs`: VirtoCommerce/vc-docs#70