### PR TITLE
fix(vc-data-table): eliminate initial column width flash on first load

### DIFF
--- a/framework/ui/components/organisms/vc-data-table/composables/useTableColumns.test.ts
+++ b/framework/ui/components/organisms/vc-data-table/composables/useTableColumns.test.ts
@@ -260,3 +260,53 @@ describe("useTableColumns — getEffectiveColumnWidth", () => {
     expect(getEffectiveColumnWidth({ id: "sel", selectionMode: "multiple" } as unknown as VcColumnProps)).toBe("40px");
   });
 });
+
+describe("useTableColumns — getEffectiveColumnWidth initial fallback (engine not computed yet)", () => {
+  it("falls back to declared px width before engine computes", () => {
+    const cols = [makeColumn("name", { width: 200 })];
+    const visibleColumns = ref(cols);
+    // availableWidth=0 → engine cannot compute → engineOutput stays empty.
+    const { getEffectiveColumnWidth, engineOutput } = useTableColumns({
+      visibleColumns,
+      getAvailableWidth: () => 0,
+    });
+    expect(engineOutput.value.widths["name"]).toBeUndefined();
+    expect(getEffectiveColumnWidth({ id: "name", width: 200 } as VcColumnProps)).toBe("200px");
+  });
+
+  it("falls back to declared px string width ('150px') before engine computes", () => {
+    const cols = [makeColumn("name", { width: "150px" })];
+    const visibleColumns = ref(cols);
+    const { getEffectiveColumnWidth } = useTableColumns({ visibleColumns, getAvailableWidth: () => 0 });
+    expect(getEffectiveColumnWidth({ id: "name", width: "150px" } as unknown as VcColumnProps)).toBe("150px");
+  });
+
+  it("falls back to declared percent width before engine computes", () => {
+    const cols = [makeColumn("name", { width: "50%" })];
+    const visibleColumns = ref(cols);
+    const { getEffectiveColumnWidth } = useTableColumns({ visibleColumns, getAvailableWidth: () => 0 });
+    expect(getEffectiveColumnWidth({ id: "name", width: "50%" } as unknown as VcColumnProps)).toBe("50%");
+  });
+
+  it("returns undefined for auto columns (no declared width) before engine computes", () => {
+    const cols = [makeColumn("name")];
+    const visibleColumns = ref(cols);
+    const { getEffectiveColumnWidth } = useTableColumns({ visibleColumns, getAvailableWidth: () => 0 });
+    expect(getEffectiveColumnWidth({ id: "name" } as VcColumnProps)).toBeUndefined();
+  });
+
+  it("returns undefined for unsupported CSS units (e.g. 10rem) before engine computes", () => {
+    const cols = [makeColumn("name", { width: "10rem" })];
+    const visibleColumns = ref(cols);
+    const { getEffectiveColumnWidth } = useTableColumns({ visibleColumns, getAvailableWidth: () => 0 });
+    expect(getEffectiveColumnWidth({ id: "name", width: "10rem" } as unknown as VcColumnProps)).toBeUndefined();
+  });
+
+  it("engine output takes precedence over declared width once computed", () => {
+    const cols = [makeColumn("name", { width: 200 })];
+    const visibleColumns = ref(cols);
+    const { getEffectiveColumnWidth, engineOutput } = useTableColumns({ visibleColumns, getAvailableWidth: () => 0 });
+    engineOutput.value = { widths: { name: 250 }, fillerWidth: 0 };
+    expect(getEffectiveColumnWidth({ id: "name", width: 200 } as VcColumnProps)).toBe("250px");
+  });
+});

--- a/framework/ui/components/organisms/vc-data-table/composables/useTableColumns.ts
+++ b/framework/ui/components/organisms/vc-data-table/composables/useTableColumns.ts
@@ -103,9 +103,18 @@ export function useTableColumns(options: UseTableColumnsOptions): UseTableColumn
     if (col.expander) return `${SPECIAL_COLUMN_WIDTHS.expander}px`;
     if (col.rowEditor) return `${SPECIAL_COLUMN_WIDTHS.rowEditor}px`;
     const w = engineOutput.value.widths[col.id];
-    // Returning undefined signals "engine hasn't computed yet" — TableHead/TableCell
-    // use a flex:1 fallback to avoid left-pack flash during the initial render.
     if (w !== undefined && w > 0) return `${w}px`;
+    // Engine hasn't computed yet (first paint — availableWidth not measurable).
+    // Fall back to the column's DECLARED width so the first frame already matches
+    // the engine's fixed/auto layout: TableHead renders `flex: 0 0 <declared>` for
+    // fixed/percent columns and `flex: 1 1 0` for auto columns. For px/auto this is
+    // identical to the engine's result; for percent columns it can differ by a few
+    // px on the first frame (CSS resolves % against the wrapper width, which still
+    // includes special cells, vs the engine's special-cell-excluded availableWidth),
+    // corrected on the first recompute. This eliminates the equal-distribution flash.
+    const declared = parseColumnWidth(col.width, 0);
+    if (declared.type === "px") return `${declared.desiredPx}px`;
+    if (declared.type === "percent" && typeof col.width === "string") return col.width.trim();
     return undefined;
   };
 

--- a/framework/ui/components/organisms/vc-data-table/composables/useTableColumnsResize.test.ts
+++ b/framework/ui/components/organisms/vc-data-table/composables/useTableColumnsResize.test.ts
@@ -284,3 +284,61 @@ describe("weight-based resize behavior", () => {
     expect(engineOutput.value.fillerWidth).toBe(0);
   });
 });
+
+describe("useTableColumnsResize — initial recompute timing (Approach B)", () => {
+  let roCallback: (() => void) | null = null;
+  let observeSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    roCallback = null;
+    observeSpy = vi.fn();
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(cb: () => void) {
+          roCallback = cb;
+        }
+        observe = observeSpy;
+        disconnect = vi.fn();
+        unobserve = vi.fn();
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("computes immediately on the first ResizeObserver tick (no 100ms debounce)", () => {
+    const columnState = ref(makeColumnState(["a", "b"]));
+    const engineOutput = ref(makeEngineOutput({}));
+    const recompute = vi.fn();
+    const containerEl = ref<HTMLElement | null>(document.createElement("div"));
+
+    const { wrapper } = mountWithSetup(() =>
+      useTableColumnsResize({
+        columnState,
+        engineOutput,
+        recompute,
+        getAvailableWidth: () => 500,
+        minColumnWidth: 40,
+        containerEl,
+      }),
+    );
+
+    // The containerEl watch (immediate) sets up the observer synchronously.
+    expect(observeSpy).toHaveBeenCalled();
+    expect(typeof roCallback).toBe("function");
+
+    // First tick must call recompute() synchronously — without advancing any timer.
+    roCallback!();
+    expect(recompute).toHaveBeenCalledTimes(1);
+
+    // Post-settle ticks route through scheduleRecompute (rAF-throttled), so a
+    // second synchronous tick must NOT call recompute() again before the frame flushes.
+    roCallback!();
+    expect(recompute).toHaveBeenCalledTimes(1);
+
+    wrapper.unmount();
+  });
+});

--- a/framework/ui/components/organisms/vc-data-table/composables/useTableColumnsResize.ts
+++ b/framework/ui/components/organisms/vc-data-table/composables/useTableColumnsResize.ts
@@ -23,7 +23,7 @@ export interface UseTableColumnsResizeOptions {
  * On drag start, snapshots current weights.
  * During drag, converts pixel delta to weight delta and redistributes
  * among right neighbors. On end, commits to columnState.
- * Container resize calls recompute() after debounce, then rAF-throttled.
+ * Container resize calls recompute() immediately on the first tick, then rAF-throttled.
  */
 export function useTableColumnsResize(options: UseTableColumnsResizeOptions) {
   const {
@@ -215,18 +215,19 @@ export function useTableColumnsResize(options: UseTableColumnsResizeOptions) {
   // --- Container ResizeObserver: recompute on container resize ---
   //
   // Flow:
-  //   1. Initial burst of ticks during mount/blade-open animation → debounced
-  //      by 100ms to wait for layout to "settle" before the first compute.
-  //   2. After settle, subsequent ticks → throttled via requestAnimationFrame
-  //      to at most one recompute per frame. Prevents layout thrash during
-  //      continuous animations (blade open/close takes ~300ms, 18 ticks).
+  //   1. First tick (mount / blade-open): compute immediately so exact px widths
+  //      land on the first frame. The proportional CSS fallback in
+  //      getEffectiveColumnWidth makes the initial paint correct; this just locks
+  //      in exact px values without any artificial delay.
+  //   2. Subsequent ticks → rAF-throttled to at most one recompute per frame.
+  //      Prevents layout thrash during continuous animations (blade open/close
+  //      takes ~300ms, ~18 ticks).
   //
   // `recompute()` queries DOM (getBoundingClientRect) and runs the engine;
-  // calling it synchronously on every tick can cause visible jank.
+  // calling it on every tick after the first would cause visible jank.
 
   let resizeObserver: ResizeObserver | null = null;
   let settled = false;
-  let settleDebounce: ReturnType<typeof setTimeout> | undefined;
   let rafRecomputeId = 0;
 
   const scheduleRecompute = () => {
@@ -241,20 +242,17 @@ export function useTableColumnsResize(options: UseTableColumnsResizeOptions) {
     if (!containerEl?.value || typeof ResizeObserver === "undefined") return;
 
     settled = false;
-    if (settleDebounce !== undefined) {
-      clearTimeout(settleDebounce);
-      settleDebounce = undefined;
-    }
 
     resizeObserver = new ResizeObserver(() => {
       if (isResizing.value) return;
       if (!settled) {
-        if (settleDebounce !== undefined) clearTimeout(settleDebounce);
-        settleDebounce = setTimeout(() => {
-          settleDebounce = undefined;
-          settled = true;
-          recompute();
-        }, 100);
+        // First observed tick: compute immediately so exact px widths land on the
+        // first frame. The proportional CSS fallback in getEffectiveColumnWidth
+        // already makes the initial paint correct; computing now just locks exact
+        // px without the previous 100ms delay. Weights are proportional, so even a
+        // mid-animation width scales correctly and refines on subsequent ticks.
+        settled = true;
+        recompute();
         return;
       }
       // Post-settle: rAF-throttle to avoid layout thrash during animations.
@@ -276,7 +274,6 @@ export function useTableColumnsResize(options: UseTableColumnsResizeOptions) {
   }
 
   onBeforeUnmount(() => {
-    if (settleDebounce !== undefined) clearTimeout(settleDebounce);
     if (rafRecomputeId) cancelAnimationFrame(rafRecomputeId);
     resizeObserver?.disconnect();
     if (isResizing.value) {


### PR DESCRIPTION
## Problem

On first page load (no saved column widths in localStorage), VcDataTable columns render equal-width for a moment, then jump to their weighted widths — a visible flash where the first column appears wider, then shrinks.

## Root cause

1. Before the width engine can measure `availableWidth` (DOM not mounted yet), `getEffectiveColumnWidth` returned `undefined` for every column. `TableHead` then rendered `flex: 1 1 0px` (equal distribution) for all columns — **including** columns with declared fixed widths — so the first paint never matched the engine's layout.
2. The first real compute was deferred ~100ms by the `ResizeObserver` settle debounce, widening the visible window of the wrong layout.

## Fix

**A — Proportional fallback from props.** `getEffectiveColumnWidth` now falls back to the column's *declared* width while engine output is empty:
- px / number → `"<px>px"` → `flex: 0 0 <px>px`
- percent → original string → `flex: 0 0 <n>%`
- auto (no width) → `undefined` → `flex: 1 1 0` (unchanged)

The first CSS paint now matches the engine's fixed/auto layout, eliminating the equal-distribution flash.

**B — Immediate first recompute.** The first `ResizeObserver` tick calls `recompute()` synchronously (removed the 100ms `setTimeout` debounce and the `settleDebounce` variable). Subsequent ticks keep the rAF throttle, so exact pixel widths land in the first frame.

## Known minor

For percent columns coexisting with special columns, the CSS `%` (resolved against the wrapper width, which includes special cells) can differ by a few px from the engine's `%` (resolved against `availableWidth`, special cells excluded) for a single frame — corrected on the first recompute. Documented inline.

## Tests

- `useTableColumns.test.ts`: 6 new tests for the declared-width fallback (px / px-string / percent / auto / unsupported-unit / engine-precedence).
- `useTableColumnsResize.test.ts`: new test proving synchronous recompute on the first ResizeObserver tick + rAF-throttle on the second.
- Full suite: 528/528 vc-data-table tests pass, `typecheck` clean, no circular dependencies.