### PR TITLE
fix(vite-config): proxy lowercase /modules path to platform in dev server

### DIFF
--- a/configs/vite-config/src/templates/vite.application.appconfig.ts
+++ b/configs/vite-config/src/templates/vite.application.appconfig.ts
@@ -82,7 +82,10 @@ const appVendorChunks: Array<{ chunk: string; patterns: RegExp[] }> = [
 const appBasePath = process.env.APP_BASE_PATH || "/";
 const appBasePathWithSlash = appBasePath.endsWith("/") ? appBasePath : `${appBasePath}/`;
 
-const proxyPaths = ["/api", "/connect/token", "/Modules", "/images", "/pushNotificationHub"];
+// NOTE: Vite proxy prefix matching is case-sensitive. The platform serves module
+// assets under lowercase "/modules" (MF remoteEntry.js paths from the app manifest),
+// while legacy paths use "/Modules" — both must be listed.
+const proxyPaths = ["/api", "/connect/token", "/modules", "/Modules", "/images", "/pushNotificationHub"];
 
 const commonProxyOptions = process.env.APP_PLATFORM_URL ? getProxyOptions(process.env.APP_PLATFORM_URL) : "";
 


### PR DESCRIPTION
## Problem

Module Federation remotes built with `packages/mf-*` load fine in production but fail during local development: the host fetches the app manifest via the `/api` proxy, gets entry paths like

```
/modules/$(VirtoCommerce.MarketplaceRegistration)/.../remoteEntry.js?v=...
```

and the resulting request to `https://localhost:8080/modules/...` is answered by the Vite dev server itself (index.html / 404) instead of being proxied to the platform.

## Root cause

- `proxyPaths` only listed legacy `/Modules` (capital M), while the platform manifest emits lowercase `/modules/...`. Vite proxy prefix matching (`url.startsWith`) is **case-sensitive**; the ASP.NET backend is case-insensitive, which masked the mismatch in production.
- The `^/` catch-all proxy doesn't cover it either: with `APP_BASE_PATH=/` (the `create-vc-app` standalone default) its `bypass` matches `url.startsWith("/")` for every request, so nothing is proxied through it.
- Production is unaffected because the app and the platform share the same origin — no proxy involved.

## Fix

Add lowercase `/modules` to `proxyPaths` alongside `/Modules`.

## Verification

Reproduced with a minimal Vite server using the exact same proxy config against a live platform:

| Request | Before | After |
|---|---|---|
| `/modules/$(VirtoCommerce.Import)/plugins/vendor-portal/remoteEntry.js` | `200 text/html` (local index.html, not proxied) | `200 text/javascript` (proxied) |
| `/Modules/...` | `200 text/javascript` | `200 text/javascript` |
| `/api/apps/vendor-portal/manifest` | `200 application/json` | `200 application/json` |

`tsc --noEmit` on `configs/vite-config` passes.