### PR TITLE
feat(api-client): robust APP_PLATFORM_MODULES parsing + bundled framework/vc-blade fixes

### DIFF
--- a/cli/api-client/README.md
+++ b/cli/api-client/README.md
@@ -56,19 +56,22 @@ Add the dependencies to your project's **package.json**:
 
    The options are listed in the table below:
 
-   | Options                      | Description                                                                                                                                                                                                                          | Example                                                                  |
-   | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-   | `--APP_PLATFORM_MODULES`     | Platform modules to generate API client.<br>{==string[]==} <br> Supports spaces in module lists: `[Module1, Module2]` or `[Module1,Module2]`<br>Customize the `--APP_PLATFORM_MODULES` list<br>to match your project's requirements. | `--APP_PLATFORM_MODULES='[VirtoCommerce.Catalog, VirtoCommerce.Orders]'` |
-   | `--APP_API_CLIENT_DIRECTORY` | Output directory for generated API clients. <br>{==string==}                                                                                                                                                                         | `--APP_API_CLIENT_DIRECTORY=./src/api_client/`                           |
-   | `--APP_PLATFORM_URL`         | Platform URL to obtain client API configs. <br>{==string==}                                                                                                                                                                          | `--APP_PLATFORM_URL=https://vcmp-dev.govirto.com/`                       |
-   | `--APP_TYPE_STYLE`           | Sets the type style for generated DTOs. Can be 'Class' or 'Interface'.<br>{==string==}                                                                                                                                               | `--APP_TYPE_STYLE=Interface`                                             |
-   | `--VERBOSE`                  | Enable verbose logging. <br>{==boolean==}                                                                                                                                                                                            | `--VERBOSE=true`                                                         |
+   | Options                      | Description                                                                                                                                                                                                                                                                   | Example                                                                  |
+   | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+   | `--APP_PLATFORM_MODULES`     | Platform modules to generate API client.<br>{==string[]==} <br> **Always quote the value** so the shell does not split it: `'[Module1, Module2]'`. Spaces inside quotes are fine. The generator validates the value and fails fast with a quoting hint if it looks truncated. | `--APP_PLATFORM_MODULES='[VirtoCommerce.Catalog, VirtoCommerce.Orders]'` |
+   | `--APP_API_CLIENT_DIRECTORY` | Output directory for generated API clients. <br>{==string==}                                                                                                                                                                                                                  | `--APP_API_CLIENT_DIRECTORY=./src/api_client/`                           |
+   | `--APP_PLATFORM_URL`         | Platform URL to obtain client API configs. <br>{==string==}                                                                                                                                                                                                                   | `--APP_PLATFORM_URL=https://vcmp-dev.govirto.com/`                       |
+   | `--APP_TYPE_STYLE`           | Sets the type style for generated DTOs. Can be 'Class' or 'Interface'.<br>{==string==}                                                                                                                                                                                        | `--APP_TYPE_STYLE=Interface`                                             |
+   | `--VERBOSE`                  | Enable verbose logging. <br>{==boolean==}                                                                                                                                                                                                                                     | `--VERBOSE=true`                                                         |
 
    !!! note
    For the `--APP_TYPE_STYLE` parameter, use **exactly** `"Class"` or `"Interface"` (case-sensitive). Any other value will cause an error.
 
    !!! tip
    Use `--APP_TYPE_STYLE=Interface` for better TypeScript integration and smaller bundle sizes. Use `--APP_TYPE_STYLE=Class` when you need runtime type checking or class-specific features.
+
+   !!! warning
+   When passing `--APP_PLATFORM_MODULES` on the command line, wrap the value in quotes. Without quotes, the shell splits `[A, B]` on the space and only the first module is seen — the generator now detects this and exits with an error instead of silently generating a partial client.
 
 3. Configure Platform URL and other settings in your project's **.env** file:
 

--- a/cli/api-client/src/index.ts
+++ b/cli/api-client/src/index.ts
@@ -703,9 +703,16 @@ function parsePlatformModules(
   // Repeated flag → mri yields an array. Join into a single comma-separated string.
   const raw = Array.isArray(rawValue) ? rawValue.join(",") : (rawValue ?? "");
 
+  const openCount = (raw.match(/\[/g) ?? []).length;
+  const closeCount = (raw.match(/\]/g) ?? []).length;
+  const hasUnbalancedBrackets = openCount !== closeCount;
+
   // Unquoted value with spaces: the shell split it and mri parked the tail in positional
-  // args. Only meaningful for CLI input — values from .env arrive intact as one string.
-  if (!fromEnv && strayArgs.length > 0) {
+  // args. Only meaningful for CLI input (values from .env arrive intact as one string), and
+  // only when the value itself looks partial — unbalanced brackets or a trailing comma —
+  // so an unrelated positional argument alongside a complete value does not false-positive.
+  const looksPartial = hasUnbalancedBrackets || raw.trim().endsWith(",");
+  if (!fromEnv && strayArgs.length > 0 && looksPartial) {
     const reconstructed = [raw, ...strayArgs].join(" ");
     return {
       ok: false,
@@ -717,9 +724,7 @@ function parsePlatformModules(
   }
 
   // Unbalanced brackets → the value was truncated (typically missing quotes).
-  const openCount = (raw.match(/\[/g) ?? []).length;
-  const closeCount = (raw.match(/\]/g) ?? []).length;
-  if (openCount !== closeCount) {
+  if (hasUnbalancedBrackets) {
     return {
       ok: false,
       message: `APP_PLATFORM_MODULES has unbalanced brackets: ${raw}`,

--- a/cli/api-client/src/index.ts
+++ b/cli/api-client/src/index.ts
@@ -30,6 +30,7 @@ interface ApiClientArgs {
 interface ResolvedConfig {
   platformUrl: string;
   platformModules: string;
+  platformModulesList: string[];
   apiClientDirectory: string;
   packageName?: string;
   packageVersion?: string;
@@ -674,6 +675,76 @@ function detectExistingTypeStyle(apiClientDirectory: string): "Class" | "Interfa
 }
 
 /**
+ * Discriminated result of module-list parsing.
+ */
+type PlatformModulesParseResult = { ok: true; modules: string[] } | { ok: false; message: string; hint?: string };
+
+/**
+ * Normalizes and validates the raw APP_PLATFORM_MODULES value into a clean module list.
+ *
+ * Handles three otherwise-silent or cryptic failure modes:
+ * - Repeated flag (`--APP_PLATFORM_MODULES=A --APP_PLATFORM_MODULES=B`) → mri yields an
+ *   array → joined into one comma-separated list (previously threw a TypeError).
+ * - Unquoted value with spaces (`[A, B]`) → the shell splits it and mri parks the tail in
+ *   positional args (`strayArgs`) → detected and reported with a quoting hint.
+ * - Unbalanced brackets (truncated value) → detected and reported.
+ *
+ * Returns a discriminated result; the caller is responsible for printing and exiting.
+ *
+ * @param rawValue   value from process.env (string) or mri (string | string[])
+ * @param strayArgs  mri positional args (`parsedArgs._`)
+ * @param fromEnv    whether the value came from process.env (stray-arg check is skipped then)
+ */
+function parsePlatformModules(
+  rawValue: string | string[] | undefined,
+  strayArgs: string[],
+  fromEnv: boolean,
+): PlatformModulesParseResult {
+  // Repeated flag → mri yields an array. Join into a single comma-separated string.
+  const raw = Array.isArray(rawValue) ? rawValue.join(",") : (rawValue ?? "");
+
+  // Unquoted value with spaces: the shell split it and mri parked the tail in positional
+  // args. Only meaningful for CLI input — values from .env arrive intact as one string.
+  if (!fromEnv && strayArgs.length > 0) {
+    const reconstructed = [raw, ...strayArgs].join(" ");
+    return {
+      ok: false,
+      message: `APP_PLATFORM_MODULES looks truncated — unexpected extra arguments were received: ${strayArgs.join(
+        ", ",
+      )}`,
+      hint: `This usually means the value was not quoted and the shell split it on spaces.\nWrap the whole value in quotes, e.g.\n  --APP_PLATFORM_MODULES='${reconstructed}'`,
+    };
+  }
+
+  // Unbalanced brackets → the value was truncated (typically missing quotes).
+  const openCount = (raw.match(/\[/g) ?? []).length;
+  const closeCount = (raw.match(/\]/g) ?? []).length;
+  if (openCount !== closeCount) {
+    return {
+      ok: false,
+      message: `APP_PLATFORM_MODULES has unbalanced brackets: ${raw}`,
+      hint: `The value appears truncated. Wrap it in quotes, e.g.\n  --APP_PLATFORM_MODULES='[VirtoCommerce.Catalog, VirtoCommerce.Orders]'`,
+    };
+  }
+
+  const modules = raw
+    .replace(/[[\]]/g, "") // Remove brackets
+    .split(",") // Split by comma
+    .map((module) => module.trim()) // Trim whitespace from each module
+    .filter((module) => module.length > 0); // Remove empty entries
+
+  if (modules.length === 0) {
+    return {
+      ok: false,
+      message: `APP_PLATFORM_MODULES did not contain any module names: ${raw}`,
+      hint: `Provide at least one module, e.g.\n  --APP_PLATFORM_MODULES='[VirtoCommerce.Catalog]'`,
+    };
+  }
+
+  return { ok: true, modules };
+}
+
+/**
  * Parses and validates CLI arguments and environment variables into a resolved configuration.
  */
 function parseAndValidateArgs(): ResolvedConfig {
@@ -688,7 +759,11 @@ function parseAndValidateArgs(): ResolvedConfig {
     : rawPlatformUrl
       ? `${rawPlatformUrl}/`
       : rawPlatformUrl;
-  const platformModules = process.env.APP_PLATFORM_MODULES ?? parsedArgs.APP_PLATFORM_MODULES;
+  const platformModulesFromEnv = process.env.APP_PLATFORM_MODULES !== undefined;
+  const rawPlatformModules: string | string[] | undefined = platformModulesFromEnv
+    ? process.env.APP_PLATFORM_MODULES
+    : (parsedArgs.APP_PLATFORM_MODULES as string | string[] | undefined);
+  const strayArgs = ((parsedArgs as unknown as { _?: string[] })._ ?? []).map(String);
   const apiClientDirectory = process.env.APP_API_CLIENT_DIRECTORY ?? parsedArgs.APP_API_CLIENT_DIRECTORY;
   const packageName = process.env.APP_PACKAGE_NAME ?? parsedArgs.APP_PACKAGE_NAME;
   const packageVersion = process.env.APP_PACKAGE_VERSION ?? parsedArgs.APP_PACKAGE_VERSION;
@@ -758,13 +833,31 @@ function parseAndValidateArgs(): ResolvedConfig {
     process.exit(1);
   }
 
-  if (!platformModules) {
+  if (rawPlatformModules === undefined || rawPlatformModules === "") {
     console.error(
       "api-client-generator %s APP_PLATFORM_MODULES is required in .env config or as api-client-generator argument",
       chalk.red("error"),
     );
     process.exit(1);
   }
+
+  const moduleParse = parsePlatformModules(rawPlatformModules, strayArgs, platformModulesFromEnv);
+  if (!moduleParse.ok) {
+    console.error("api-client-generator %s %s", chalk.red("error"), moduleParse.message);
+    if (moduleParse.hint) {
+      console.error(chalk.blue(moduleParse.hint));
+    }
+    process.exit(1);
+  }
+  const platformModulesList = moduleParse.modules;
+  const platformModules = platformModulesList.join(",");
+
+  console.log(
+    "api-client-generator %s Parsed %d module(s): %s",
+    chalk.blue("info"),
+    platformModulesList.length,
+    chalk.whiteBright(platformModulesList.join(", ")),
+  );
 
   if (!apiClientDirectory) {
     console.error(
@@ -791,6 +884,7 @@ function parseAndValidateArgs(): ResolvedConfig {
   return {
     platformUrl,
     platformModules,
+    platformModulesList,
     apiClientDirectory,
     packageName,
     packageVersion,
@@ -836,12 +930,8 @@ function generateClients(config: ResolvedConfig): string[] {
     }
   }
 
-  // Parse platform modules with improved space handling
-  const platformModulesList = config.platformModules
-    .replace(/[[\]]/g, "") // Remove brackets
-    .split(",") // Split by comma
-    .map((module) => module.trim()) // Trim whitespace from each module
-    .filter((module) => module.length > 0); // Remove empty entries
+  // Module list was parsed and validated in parseAndValidateArgs.
+  const platformModulesList = config.platformModulesList;
 
   const generatedFiles: string[] = [];
 

--- a/cli/api-client/src/index.ts
+++ b/cli/api-client/src/index.ts
@@ -29,7 +29,6 @@ interface ApiClientArgs {
  */
 interface ResolvedConfig {
   platformUrl: string;
-  platformModules: string;
   platformModulesList: string[];
   apiClientDirectory: string;
   packageName?: string;
@@ -855,7 +854,6 @@ function parseAndValidateArgs(): ResolvedConfig {
     process.exit(1);
   }
   const platformModulesList = moduleParse.modules;
-  const platformModules = platformModulesList.join(",");
 
   console.log(
     "api-client-generator %s Parsed %d module(s): %s",
@@ -888,7 +886,6 @@ function parseAndValidateArgs(): ResolvedConfig {
 
   return {
     platformUrl,
-    platformModules,
     platformModulesList,
     apiClientDirectory,
     packageName,

--- a/framework/core/utilities/buildInfo.test.ts
+++ b/framework/core/utilities/buildInfo.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getFrameworkBuildInfo, logFrameworkBuildInfo } from "./buildInfo";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getFrameworkBuildInfo", () => {
+  it("falls back to 'dev' when Vite build constants are not defined", () => {
+    // Vitest does not apply the framework's Vite `define`, so the __VC_SHELL_*
+    // constants are genuinely undefined at runtime here — this exercises the
+    // dev-mode fallback path.
+    const info = getFrameworkBuildInfo();
+    expect(info).toEqual({ version: "dev", buildDate: "dev", gitHash: "dev" });
+  });
+});
+
+describe("logFrameworkBuildInfo", () => {
+  it("logs exactly one line containing version, build date and git hash", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    logFrameworkBuildInfo({
+      version: "2.0.7",
+      buildDate: "2026-06-09T10:00:00.000Z",
+      gitHash: "a1b2c3d",
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const message = spy.mock.calls[0].join(" ");
+    expect(message).toContain("@vc-shell/framework");
+    expect(message).toContain("2.0.7");
+    expect(message).toContain("2026-06-09T10:00:00.000Z");
+    expect(message).toContain("a1b2c3d");
+  });
+});

--- a/framework/core/utilities/buildInfo.test.ts
+++ b/framework/core/utilities/buildInfo.test.ts
@@ -26,10 +26,11 @@ describe("logFrameworkBuildInfo", () => {
     });
 
     expect(spy).toHaveBeenCalledTimes(1);
-    const message = spy.mock.calls[0].join(" ");
-    expect(message).toContain("@vc-shell/framework");
-    expect(message).toContain("2.0.7");
-    expect(message).toContain("2026-06-09T10:00:00.000Z");
-    expect(message).toContain("a1b2c3d");
+    expect(spy.mock.calls[0]).toHaveLength(3);
+    const formatString = spy.mock.calls[0][0] as string;
+    expect(formatString).toContain("@vc-shell/framework");
+    expect(formatString).toContain("2.0.7");
+    expect(formatString).toContain("2026-06-09T10:00:00.000Z");
+    expect(formatString).toContain("a1b2c3d");
   });
 });

--- a/framework/core/utilities/buildInfo.ts
+++ b/framework/core/utilities/buildInfo.ts
@@ -1,0 +1,30 @@
+/**
+ * Build-time constants injected by Vite `define` in `framework/vite.config.mts`
+ * during `vite build` of the framework. They are frozen at framework publish
+ * time, so a consuming app reads the framework version it was built against.
+ *
+ * In dev mode (framework source consumed via alias, Storybook, or Vitest) the
+ * `define` is not applied. `typeof <undeclared>` returns `"undefined"` without
+ * throwing a ReferenceError, so the guard yields the "dev" fallback.
+ */
+export interface FrameworkBuildInfo {
+  version: string;
+  buildDate: string;
+  gitHash: string;
+}
+
+export function getFrameworkBuildInfo(): FrameworkBuildInfo {
+  return {
+    version: typeof __VC_SHELL_VERSION__ !== "undefined" ? __VC_SHELL_VERSION__ : "dev",
+    buildDate: typeof __VC_SHELL_BUILD_DATE__ !== "undefined" ? __VC_SHELL_BUILD_DATE__ : "dev",
+    gitHash: typeof __VC_SHELL_GIT_HASH__ !== "undefined" ? __VC_SHELL_GIT_HASH__ : "dev",
+  };
+}
+
+export function logFrameworkBuildInfo(info: FrameworkBuildInfo = getFrameworkBuildInfo()): void {
+  console.log(
+    `%c@vc-shell/framework%c v${info.version} · ${info.buildDate} · ${info.gitHash}`,
+    "font-weight:bold;color:#319ED4",
+    "color:inherit",
+  );
+}

--- a/framework/core/utilities/buildInfo.ts
+++ b/framework/core/utilities/buildInfo.ts
@@ -7,13 +7,13 @@
  * `define` is not applied. `typeof <undeclared>` returns `"undefined"` without
  * throwing a ReferenceError, so the guard yields the "dev" fallback.
  */
-export interface FrameworkBuildInfo {
+export interface IFrameworkBuildInfo {
   version: string;
   buildDate: string;
   gitHash: string;
 }
 
-export function getFrameworkBuildInfo(): FrameworkBuildInfo {
+export function getFrameworkBuildInfo(): IFrameworkBuildInfo {
   return {
     version: typeof __VC_SHELL_VERSION__ !== "undefined" ? __VC_SHELL_VERSION__ : "dev",
     buildDate: typeof __VC_SHELL_BUILD_DATE__ !== "undefined" ? __VC_SHELL_BUILD_DATE__ : "dev",
@@ -21,7 +21,9 @@ export function getFrameworkBuildInfo(): FrameworkBuildInfo {
   };
 }
 
-export function logFrameworkBuildInfo(info: FrameworkBuildInfo = getFrameworkBuildInfo()): void {
+export function logFrameworkBuildInfo(info: IFrameworkBuildInfo = getFrameworkBuildInfo()): void {
+  // Direct console.log (not the logger util): the %c CSS styling is not supported
+  // by the logger abstraction, and this banner must always print for debugging.
   console.log(
     `%c@vc-shell/framework%c v${info.version} · ${info.buildDate} · ${info.gitHash}`,
     "font-weight:bold;color:#319ED4",

--- a/framework/typings/build-constants.d.ts
+++ b/framework/typings/build-constants.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Build-time constants injected by Vite `define` (see framework/vite.config.mts).
+ * Declared here (under typings/, which is in tsconfig `include` but NOT in
+ * package.json "files") so they type-check during the framework's own build and
+ * do NOT leak into apps consuming @vc-shell/framework.
+ */
+declare const __VC_SHELL_VERSION__: string;
+declare const __VC_SHELL_BUILD_DATE__: string;
+declare const __VC_SHELL_GIT_HASH__: string;

--- a/framework/ui/components/organisms/vc-blade/_internal/toolbar/ToolbarMobile.test.ts
+++ b/framework/ui/components/organisms/vc-blade/_internal/toolbar/ToolbarMobile.test.ts
@@ -134,12 +134,18 @@ describe("ToolbarMobile", () => {
     expect(firstAction.attributes("disabled")).toBeDefined();
   });
 
-  it("applies primary icon class to first action item", async () => {
+  it("applies the unified action icon class to all items (no per-item primary modifier)", async () => {
     const wrapper = mountToolbar([createToolbarItem({ id: "1" }), createToolbarItem({ id: "2" })]);
 
     await wrapper.find(".vc-blade-toolbar-mobile__pill-more").trigger("click");
-    const firstIcon = wrapper.findAll(".vc-blade-toolbar-mobile__action-icon")[0];
-    expect(firstIcon.classes()).toContain("vc-blade-toolbar-mobile__action-icon--primary");
+    const icons = wrapper.findAll(".vc-blade-toolbar-mobile__action-icon");
+    expect(icons.length).toBeGreaterThan(0);
+    // Expanded toolbar unifies action colors: every icon uses the base class and
+    // the former `--primary` modifier (previously on the first item) is gone.
+    icons.forEach((icon) => {
+      expect(icon.classes()).toContain("vc-blade-toolbar-mobile__action-icon");
+      expect(icon.classes()).not.toContain("vc-blade-toolbar-mobile__action-icon--primary");
+    });
   });
 
   it("resolves function-based icon", () => {

--- a/framework/ui/components/organisms/vc-blade/_internal/toolbar/ToolbarMobile.vue
+++ b/framework/ui/components/organisms/vc-blade/_internal/toolbar/ToolbarMobile.vue
@@ -37,7 +37,6 @@
         </span>
         <span
           class="vc-blade-toolbar-mobile__action-icon"
-          :class="{ 'vc-blade-toolbar-mobile__action-icon--primary': index === 0 }"
           aria-hidden="true"
         >
           <VcIcon
@@ -264,12 +263,8 @@ $touch-min: 44px;
 
   &__action-icon {
     @apply tw-flex tw-items-center tw-justify-center tw-w-9 tw-h-9 tw-rounded-full tw-shrink-0;
-    background: var(--blade-toolbar-circle-button-bg-color);
+    background: var(--blade-toolbar-circle-button-main-bg-color);
     color: var(--blade-toolbar-circle-button-text-color);
-
-    &--primary {
-      background: var(--blade-toolbar-circle-button-main-bg-color);
-    }
   }
 
   // ── Close FAB (expanded state) ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Bundles all previously-unpushed local commits onto a single branch. The primary work is hardening `APP_PLATFORM_MODULES` parsing in `@vc-shell/api-client-generator`; the branch also carries earlier unpushed framework and vc-blade commits.

### api-client: robust `APP_PLATFORM_MODULES` parsing
- Move parsing/validation into `parseAndValidateArgs` so it runs **before** any side effects (directory creation, NSwag), via a pure `parsePlatformModules()` returning a discriminated result.
- Fail fast with an actionable quoting hint when an unquoted value was split by the shell (stray positional args) — gated behind a `looksPartial` check (unbalanced brackets or trailing comma) to avoid false positives on unrelated positionals.
- Detect unbalanced brackets and empty module lists, each with a clear message.
- Fix the repeated-flag case (`--APP_PLATFORM_MODULES=A --APP_PLATFORM_MODULES=B`) — `mri` yields an array, which previously threw a `TypeError`; arrays are now joined.
- Echo `Parsed N module(s): …` before generation so silent partial generation is visible.
- README: clarify the quoting requirement and document the new validation.

### framework: build-info / version banner (earlier unpushed commits)
- Add build-info module for the version banner, align naming, harden tests, and declare ambient types for build constants.

### vc-blade (earlier unpushed commit)
- Unify mobile toolbar action button colors in the expanded state.

## Test Plan
- [x] `yarn typecheck` (api-client `tsc --noEmit`) passes.
- [x] Manual CLI verification of the compiled generator:
  - quoted-with-spaces `'[A, B]'` → `Parsed 2 module(s)`
  - repeated flag → `Parsed 2`, no `TypeError`
  - complete value + unrelated positional → `Parsed 2` (no false positive)
  - unquoted `A, B` → fail-fast with quoting hint, no directory created
  - unbalanced `[A` → fail-fast
- [x] Pre-commit gates (eslint, prettier, locales, layer checks) pass on every commit.