### PR TITLE
feat(framework): read framework version from package.json at runtime

### DIFF
--- a/framework/core/utilities/buildInfo.test.ts
+++ b/framework/core/utilities/buildInfo.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { version as frameworkVersion } from "../../package.json";
 import { getFrameworkBuildInfo, logFrameworkBuildInfo } from "./buildInfo";
 
 afterEach(() => {
@@ -6,12 +7,14 @@ afterEach(() => {
 });
 
 describe("getFrameworkBuildInfo", () => {
-  it("falls back to 'dev' when Vite build constants are not defined", () => {
-    // Vitest does not apply the framework's Vite `define`, so the __VC_SHELL_*
-    // constants are genuinely undefined at runtime here — this exercises the
-    // dev-mode fallback path.
+  it("reads version from package.json and falls back to 'dev' for build-time fields in source mode", () => {
+    // Vitest does not apply the framework's Vite `define`, so __VC_SHELL_BUILD_DATE__
+    // and __VC_SHELL_GIT_HASH__ are genuinely undefined here — the dev-mode fallback.
+    // version, however, is read statically from package.json and is always accurate.
     const info = getFrameworkBuildInfo();
-    expect(info).toEqual({ version: "dev", buildDate: "dev", gitHash: "dev" });
+    expect(info.version).toBe(frameworkVersion);
+    expect(info.buildDate).toBe("dev");
+    expect(info.gitHash).toBe("dev");
   });
 });
 

--- a/framework/core/utilities/buildInfo.ts
+++ b/framework/core/utilities/buildInfo.ts
@@ -1,11 +1,14 @@
+import { version as frameworkVersion } from "../../package.json";
+
 /**
- * Build-time constants injected by Vite `define` in `framework/vite.config.mts`
- * during `vite build` of the framework. They are frozen at framework publish
- * time, so a consuming app reads the framework version it was built against.
+ * `version` is read statically from the framework's `package.json`, so it is
+ * always accurate — both in a built/published framework AND when the framework
+ * is consumed from source (Storybook, dev server, Vitest).
  *
- * In dev mode (framework source consumed via alias, Storybook, or Vitest) the
- * `define` is not applied. `typeof <undeclared>` returns `"undefined"` without
- * throwing a ReferenceError, so the guard yields the "dev" fallback.
+ * `buildDate` and `gitHash` are injected by Vite `define` in
+ * `framework/vite.config.mts` during `vite build` of the framework. In source
+ * contexts the `define` is not applied; `typeof <undeclared>` returns
+ * `"undefined"` without throwing a ReferenceError, so they fall back to "dev".
  */
 export interface IFrameworkBuildInfo {
   version: string;
@@ -15,7 +18,7 @@ export interface IFrameworkBuildInfo {
 
 export function getFrameworkBuildInfo(): IFrameworkBuildInfo {
   return {
-    version: typeof __VC_SHELL_VERSION__ !== "undefined" ? __VC_SHELL_VERSION__ : "dev",
+    version: frameworkVersion,
     buildDate: typeof __VC_SHELL_BUILD_DATE__ !== "undefined" ? __VC_SHELL_BUILD_DATE__ : "dev",
     gitHash: typeof __VC_SHELL_GIT_HASH__ !== "undefined" ? __VC_SHELL_GIT_HASH__ : "dev",
   };

--- a/framework/typings/build-constants.d.ts
+++ b/framework/typings/build-constants.d.ts
@@ -4,6 +4,5 @@
  * package.json "files") so they type-check during the framework's own build and
  * do NOT leak into apps consuming @vc-shell/framework.
  */
-declare const __VC_SHELL_VERSION__: string;
 declare const __VC_SHELL_BUILD_DATE__: string;
 declare const __VC_SHELL_GIT_HASH__: string;

--- a/framework/vite.config.mts
+++ b/framework/vite.config.mts
@@ -1,7 +1,6 @@
 import vue from "@vitejs/plugin-vue";
 import { getLibraryConfiguration } from "@vc-shell/config-generator";
 import * as path from "node:path";
-import * as fs from "node:fs";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { normalizePath } from "vite";
@@ -12,7 +11,6 @@ import { viteBladePlugin } from "@vc-shell/config-generator";
 const mode = process.env.APP_ENV as string;
 const frameworkRoot = path.dirname(fileURLToPath(import.meta.url));
 const normalizedFrameworkRoot = normalizePath(frameworkRoot);
-const pkg = JSON.parse(fs.readFileSync(path.resolve(frameworkRoot, "package.json"), "utf-8"));
 
 function getGitHash(): string {
   try {
@@ -111,7 +109,8 @@ export default getLibraryConfiguration({
     },
   },
   define: {
-    __VC_SHELL_VERSION__: JSON.stringify(pkg.version),
+    // version is read at runtime from package.json (see core/utilities/buildInfo.ts);
+    // only build-time-only facts are injected here.
     __VC_SHELL_BUILD_DATE__: JSON.stringify(new Date().toISOString()),
     __VC_SHELL_GIT_HASH__: JSON.stringify(getGitHash()),
   },


### PR DESCRIPTION
## Summary

Read the framework `version` directly from `framework/package.json` instead of injecting it through Vite `define` (`__VC_SHELL_VERSION__`).

The version now stays accurate in **every** context — a built/published framework and source consumption (Storybook, dev server, Vitest) alike — without depending on the build-time `define` being applied.

Build-time-only facts (`buildDate`, `gitHash`) are still injected by Vite, so the `__VC_SHELL_BUILD_DATE__` / `__VC_SHELL_GIT_HASH__` constants and their typings remain; only `__VC_SHELL_VERSION__` is removed.

## Changes

- `core/utilities/buildInfo.ts` — import `version` from `package.json`; drop the `__VC_SHELL_VERSION__` guard.
- `vite.config.mts` — remove the `fs`/`pkg` read and the `__VC_SHELL_VERSION__` define entry; keep `buildDate`/`gitHash` injection.
- `typings/build-constants.d.ts` — drop the now-unused `__VC_SHELL_VERSION__` declaration.
- `core/utilities/buildInfo.test.ts` — assert `version` equals `package.json` version while build-time fields fall back to `dev` in source mode.

## Verification

- `npx vitest run core/utilities/buildInfo.test.ts` — passing
- `yarn typecheck` — passing
- pre-commit hooks (eslint, prettier, locales, layer checks) — passing